### PR TITLE
chore: Add vulnerable pg library for demo purposes

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "main" : "./index.js",
     "dependencies" : {
         "wordwrap" : "~0.0.2",
-        "minimist" : "~0.0.1"
+        "minimist" : "~0.0.1",
+        "pg": "7.1.0"
     },
     "devDependencies" : {
         "hashish": "~0.0.4",


### PR DESCRIPTION
The library is not in use, but note the inline PR test failed tests caused by our attempt to add a new vulnerable library.